### PR TITLE
Remove 'mapCoverage' option at jest.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,18 +229,7 @@ Snapshots:   0 total
 Time:        1.353s
 Ran all test suites.
 ---------------|----------|----------|----------|----------|----------------|
-File           |  % Stmts | % Branch |  % Funcs |  % Lines |Un
-
-
-
-
-
-
-
-
-
-
-ed Lines |
+File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 ---------------|----------|----------|----------|----------|----------------|
 All files      |      100 |      100 |      100 |      100 |                |
  src           |      100 |      100 |      100 |      100 |                |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ module.exports = {
     testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
     collectCoverage: true,
-    mapCoverage: true,
 };
 ```
 
@@ -230,7 +229,18 @@ Snapshots:   0 total
 Time:        1.353s
 Ran all test suites.
 ---------------|----------|----------|----------|----------|----------------|
-File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
+File           |  % Stmts | % Branch |  % Funcs |  % Lines |Un
+
+
+
+
+
+
+
+
+
+
+ed Lines |
 ---------------|----------|----------|----------|----------|----------------|
 All files      |      100 |      100 |      100 |      100 |                |
  src           |      100 |      100 |      100 |      100 |                |

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,4 @@ module.exports = {
     testPathIgnorePatterns: ["/lib/", "/node_modules/"],
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
     collectCoverage: true,
-    mapCoverage: true,
 };


### PR DESCRIPTION
This sample is really help for me ;)

Wnen I run jest, it says
```
● Deprecation Warning:

  Option "mapCoverage" has been removed, as it's no longer necessary.

  Please update your configuration.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

Thanks.